### PR TITLE
Let assertion method call with $this

### DIFF
--- a/test/Api/AbstractApiTest.php
+++ b/test/Api/AbstractApiTest.php
@@ -90,7 +90,7 @@ class AbstractApiTest extends ApiTestCase
         $expectedValue = ['value'];
 
         $httpClient = $this->getHttpMethodsMock(['patch']);
-        $httpClient->expects(self::once())
+        $httpClient->expects($this->once())
             ->method('patch')
             ->with('/path', ['option1' => 'option1value'], json_encode(['param1' => 'param1value']))
             ->willReturn($this->getPSR7Response($expectedValue));
@@ -98,7 +98,7 @@ class AbstractApiTest extends ApiTestCase
         $client = $this->getMockBuilder(Client::class)
             ->setMethods(['getHttpClient'])
             ->getMock();
-        $client->expects(self::any())
+        $client->expects($this->any())
             ->method('getHttpClient')
             ->willReturn($httpClient);
 
@@ -119,7 +119,7 @@ class AbstractApiTest extends ApiTestCase
         $expectedValue = ['value'];
 
         $httpClient = $this->getHttpMethodsMock(['put']);
-        $httpClient->expects(self::once())
+        $httpClient->expects($this->once())
             ->method('put')
             ->with('/path', ['option1' => 'option1value'], json_encode(['param1' => 'param1value']))
             ->willReturn($this->getPSR7Response($expectedValue));
@@ -128,7 +128,7 @@ class AbstractApiTest extends ApiTestCase
             ->setMethods(['getHttpClient'])
             ->getMock();
 
-        $client->expects(self::any())
+        $client->expects($this->any())
             ->method('getHttpClient')
             ->willReturn($httpClient);
 
@@ -149,7 +149,7 @@ class AbstractApiTest extends ApiTestCase
         $expectedValue = ['value'];
 
         $httpClient = $this->getHttpMethodsMock(['delete']);
-        $httpClient->expects(self::once())
+        $httpClient->expects($this->once())
             ->method('delete')
             ->with('/path', ['option1' => 'option1value'], json_encode(['param1' => 'param1value']))
             ->willReturn($this->getPSR7Response($expectedValue));
@@ -157,7 +157,7 @@ class AbstractApiTest extends ApiTestCase
         $client = $this->getMockBuilder(Client::class)
             ->setMethods(['getHttpClient'])
             ->getMock();
-        $client->expects(self::any())
+        $client->expects($this->any())
             ->method('getHttpClient')
             ->willReturn($httpClient);
 

--- a/test/Api/ApiTestCase.php
+++ b/test/Api/ApiTestCase.php
@@ -38,7 +38,7 @@ abstract class ApiTestCase extends TestCase
         $httpClient = $this->getMockBuilder(HttpClient::class)
             ->setMethods(['sendRequest'])
             ->getMock();
-        $httpClient->expects(self::any())
+        $httpClient->expects($this->any())
             ->method('sendRequest');
 
         $client = Client::createWithHttpClient($httpClient);

--- a/test/Api/BalanceTest.php
+++ b/test/Api/BalanceTest.php
@@ -30,7 +30,7 @@ class BalanceTest extends ApiTestCase
         $expectedResult = ['data' => [['balance' => 123000]]];
 
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('get')
             ->with(self::PATH)
             ->willReturn($expectedResult);
@@ -45,7 +45,7 @@ class BalanceTest extends ApiTestCase
     {
         $api = $this->getApiMock();
 
-        self::assertInstanceOf(Balance::class, $api);
+        $this->assertInstanceOf(Balance::class, $api);
     }
 
     /**

--- a/test/Api/BankTest.php
+++ b/test/Api/BankTest.php
@@ -30,7 +30,7 @@ class BankTest extends ApiTestCase
         $expectedResult = collect(['data' => [['name' => 'Access Bank']]]);
 
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('get')
             ->with(self::PATH)
             ->willReturn($expectedResult);
@@ -45,7 +45,7 @@ class BankTest extends ApiTestCase
     {
         $api = $this->getApiMock();
 
-        self::assertInstanceOf(Bank::class, $api);
+        $this->assertInstanceOf(Bank::class, $api);
     }
 
     /**

--- a/test/Api/BulkChargesTest.php
+++ b/test/Api/BulkChargesTest.php
@@ -31,7 +31,7 @@ class BulkChargesTest extends ApiTestCase
         $bulkChargeId = 'BCH_180tl7oq7cayggh';
 
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('get')
             ->with(self::PATH.'/'.$bulkChargeId)
             ->willReturn($expectedResult);
@@ -48,7 +48,7 @@ class BulkChargesTest extends ApiTestCase
         $bulkChargeId = 'BCH_180tl7oq7cayggh';
 
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('get')
             ->with(self::PATH.'/pause/'.$bulkChargeId)
             ->willReturn($expectedResult);
@@ -65,7 +65,7 @@ class BulkChargesTest extends ApiTestCase
         $bulkChargeId = 'BCH_180tl7oq7cayggh';
 
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('get')
             ->with(self::PATH.'/resume/'.$bulkChargeId)
             ->willReturn($expectedResult);
@@ -82,7 +82,7 @@ class BulkChargesTest extends ApiTestCase
         $bulkChargeId = 'BCH_180tl7oq7cayggh';
 
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('get')
             ->with(self::PATH.'/'.$bulkChargeId.'/charges')
             ->willReturn($expectedResult);
@@ -98,7 +98,7 @@ class BulkChargesTest extends ApiTestCase
         $expectedResult = collect(['data' => [['batch_code' => 'BCH_180tl7oq7cayggh']]]);
 
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('get')
             ->with(self::PATH)
             ->willReturn($expectedResult);
@@ -115,7 +115,7 @@ class BulkChargesTest extends ApiTestCase
         $input = [['authorization' => 'AUTH_n95vpedf']];
 
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('post')
             ->with(self::PATH, $input)
             ->willReturn($expectedResult);
@@ -130,7 +130,7 @@ class BulkChargesTest extends ApiTestCase
     {
         $api = $this->getApiMock();
 
-        self::assertInstanceOf(BulkCharges::class, $api);
+        $this->assertInstanceOf(BulkCharges::class, $api);
     }
 
     /**

--- a/test/Api/BvnTest.php
+++ b/test/Api/BvnTest.php
@@ -31,7 +31,7 @@ class BvnTest extends ApiTestCase
         $bvn = '21212917741';
 
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('get')
             ->with(self::PATH.'/resolve_bvn/'.$bvn)
             ->willReturn($expectedResult);
@@ -48,7 +48,7 @@ class BvnTest extends ApiTestCase
         $bin = '539983';
 
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('get')
             ->with('/decision/bin/'.$bin)
             ->willReturn($expectedResult);
@@ -68,7 +68,7 @@ class BvnTest extends ApiTestCase
         ];
 
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('get')
             ->with(self::PATH.'/resolve?'.http_build_query($accountDetails))
             ->willReturn($expectedResult);
@@ -89,7 +89,7 @@ class BvnTest extends ApiTestCase
         ];
 
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('post')
             ->with('/verifications', $input)
             ->willReturn($expectedResult);
@@ -104,7 +104,7 @@ class BvnTest extends ApiTestCase
     {
         $api = $this->getApiMock();
 
-        self::assertInstanceOf(Bvn::class, $api);
+        $this->assertInstanceOf(Bvn::class, $api);
     }
 
     /**

--- a/test/Api/ChargeTest.php
+++ b/test/Api/ChargeTest.php
@@ -47,7 +47,7 @@ class ChargeTest extends ApiTestCase
         ];
 
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('post')
             ->with(self::PATH, $input)
             ->willReturn($expectedResult);
@@ -73,7 +73,7 @@ class ChargeTest extends ApiTestCase
         ];
 
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('post')
             ->with(self::PATH.'/submit_pin', $input)
             ->willReturn($expectedResult);
@@ -99,7 +99,7 @@ class ChargeTest extends ApiTestCase
         ];
 
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('post')
             ->with(self::PATH.'/submit_otp', $input)
             ->willReturn($expectedResult);
@@ -125,7 +125,7 @@ class ChargeTest extends ApiTestCase
         ];
 
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('post')
             ->with(self::PATH.'/submit_phone', $input)
             ->willReturn($expectedResult);
@@ -151,7 +151,7 @@ class ChargeTest extends ApiTestCase
         ];
 
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('post')
             ->with(self::PATH.'/submit_birthday', $input)
             ->willReturn($expectedResult);
@@ -174,7 +174,7 @@ class ChargeTest extends ApiTestCase
         $reference = '0t4gwo2ft6q0n9h';
 
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('get')
             ->with(self::PATH.'/'.$reference)
             ->willReturn($expectedResult);
@@ -189,7 +189,7 @@ class ChargeTest extends ApiTestCase
     {
         $api = $this->getApiMock();
 
-        self::assertInstanceOf(Charge::class, $api);
+        $this->assertInstanceOf(Charge::class, $api);
     }
 
     /**

--- a/test/Api/CustomerTest.php
+++ b/test/Api/CustomerTest.php
@@ -28,7 +28,7 @@ class CustomerTest extends ApiTestCase
         $expectedResult = ['data' => ['email' => 'email@example.com']];
 
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('get')
             ->with('/customer/email@example.com')
             ->willReturn($expectedResult);
@@ -44,7 +44,7 @@ class CustomerTest extends ApiTestCase
         $expectedResult = collect(['data' => [['email' => 'email@example.com']]]);
 
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('get')
             ->with('/customer')
             ->willReturn($expectedResult);
@@ -61,7 +61,7 @@ class CustomerTest extends ApiTestCase
         $input = $expectedResult['data'];
 
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('post')
             ->with('/customer', $input)
             ->willReturn($expectedResult);
@@ -79,7 +79,7 @@ class CustomerTest extends ApiTestCase
         $customerId = 'email@example.com';
 
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('put')
             ->with("/customer/$customerId", $input)
             ->willReturn($expectedResult);
@@ -97,7 +97,7 @@ class CustomerTest extends ApiTestCase
         $expectedResult = ['data' => ['first_name' => 'Example Name']];
 
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('post')
             ->with('/customer/set_risk_action', $input)
             ->willReturn($expectedResult);
@@ -115,7 +115,7 @@ class CustomerTest extends ApiTestCase
         $expectedResult = ['data' => ['first_name' => 'Example Name']];
 
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('post')
             ->with('/customer/set_risk_action', $input)
             ->willReturn($expectedResult);
@@ -132,7 +132,7 @@ class CustomerTest extends ApiTestCase
         $expectedResult = ['status' => true, 'message' => 'Authorization has been disabled'];
 
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('post')
             ->with('/customer/deactivate_authorization', $input)
             ->willReturn($expectedResult);

--- a/test/Api/IntegrationTest.php
+++ b/test/Api/IntegrationTest.php
@@ -30,7 +30,7 @@ class IntegrationTest extends ApiTestCase
         $expectedResult = ['data' => ['payment_session_timeout' => 30]];
 
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('get')
             ->with(self::PATH.'/payment_session_timeout')
             ->willReturn($expectedResult);
@@ -47,7 +47,7 @@ class IntegrationTest extends ApiTestCase
         $expectedResult = ['data' => ['payment_session_timeout' => 60]];
 
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('put')
             ->with(self::PATH.'/payment_session_timeout')
             ->willReturn($expectedResult);
@@ -62,7 +62,7 @@ class IntegrationTest extends ApiTestCase
     {
         $api = $this->getApiMock();
 
-        self::assertInstanceOf(Integration::class, $api);
+        $this->assertInstanceOf(Integration::class, $api);
     }
 
     /**

--- a/test/Api/InvoicesTest.php
+++ b/test/Api/InvoicesTest.php
@@ -31,7 +31,7 @@ class InvoicesTest extends ApiTestCase
         $invoiceId = 'xb2der';
 
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('get')
             ->with(self::PATH.'/'.$invoiceId)
             ->willReturn($expectedResult);
@@ -47,7 +47,7 @@ class InvoicesTest extends ApiTestCase
         $expectedResult = ['data' => ['totals' => 900713]];
 
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('get')
             ->with(self::PATH.'/totals')
             ->willReturn($expectedResult);
@@ -64,7 +64,7 @@ class InvoicesTest extends ApiTestCase
         $invoiceId = 'xb2der';
 
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('get')
             ->with(self::PATH.'/verify/'.$invoiceId)
             ->willReturn($expectedResult);
@@ -82,7 +82,7 @@ class InvoicesTest extends ApiTestCase
         $input = [];
 
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('post')
             ->with(self::PATH.'/notify/'.$invoiceId, $input)
             ->willReturn($expectedResult);
@@ -100,7 +100,7 @@ class InvoicesTest extends ApiTestCase
         $input = [];
 
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('post')
             ->with(self::PATH.'/finalize/'.$invoiceId, $input)
             ->willReturn($expectedResult);
@@ -118,7 +118,7 @@ class InvoicesTest extends ApiTestCase
         $input = [];
 
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('post')
             ->with(self::PATH.'/archive/'.$invoiceId, $input)
             ->willReturn($expectedResult);
@@ -141,7 +141,7 @@ class InvoicesTest extends ApiTestCase
         ];
 
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('post')
             ->with(self::PATH.'/mark_as_paid/'.$invoiceId, $input)
             ->willReturn($expectedResult);
@@ -157,7 +157,7 @@ class InvoicesTest extends ApiTestCase
         $expectedResult = collect(['data' => [['id' => 900713]]]);
 
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('get')
             ->with(self::PATH)
             ->willReturn($expectedResult);
@@ -181,7 +181,7 @@ class InvoicesTest extends ApiTestCase
         ];
 
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('post')
             ->with(self::PATH, $input)
             ->willReturn($expectedResult);
@@ -199,7 +199,7 @@ class InvoicesTest extends ApiTestCase
         $invoiceId = '3x_x123';
 
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('put')
             ->with(self::PATH."/$invoiceId", $input)
             ->willReturn($expectedResult);
@@ -214,7 +214,7 @@ class InvoicesTest extends ApiTestCase
     {
         $api = $this->getApiMock();
 
-        self::assertInstanceOf(Invoices::class, $api);
+        $this->assertInstanceOf(Invoices::class, $api);
     }
 
     /**

--- a/test/Api/PagesTest.php
+++ b/test/Api/PagesTest.php
@@ -32,7 +32,7 @@ class PagesTest extends ApiTestCase
         $id = 'xb2der';
 
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('get')
             ->with(self::PATH.'/'.$id)
             ->willReturn($expectedResult);
@@ -49,7 +49,7 @@ class PagesTest extends ApiTestCase
         $slug = 'xb2der';
 
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('get')
             ->with(self::PATH.'/check_slug_availability/'.$slug)
             ->willReturn($expectedResult);
@@ -69,7 +69,7 @@ class PagesTest extends ApiTestCase
         ]);
 
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('get')
             ->with(self::PATH)
             ->willReturn($finalResult);
@@ -90,7 +90,7 @@ class PagesTest extends ApiTestCase
         ];
 
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('post')
             ->with(self::PATH, $input)
             ->willReturn($expectedResult);
@@ -108,7 +108,7 @@ class PagesTest extends ApiTestCase
         $pageId = '3x_x123';
 
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('put')
             ->with(self::PATH."/$pageId", $input)
             ->willReturn($expectedResult);
@@ -123,7 +123,7 @@ class PagesTest extends ApiTestCase
     {
         $api = $this->getApiMock();
 
-        self::assertInstanceOf(Pages::class, $api);
+        $this->assertInstanceOf(Pages::class, $api);
     }
 
     /**

--- a/test/Api/PlansTest.php
+++ b/test/Api/PlansTest.php
@@ -29,7 +29,7 @@ class PlansTest extends ApiTestCase
         $plan = 'PLN_x123';
 
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('get')
             ->with('/plan/'.$plan)
             ->willReturn($expectedResult);
@@ -45,7 +45,7 @@ class PlansTest extends ApiTestCase
         $expectedResult = collect([['integration' => 900713]]);
 
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('get')
             ->with('/plan')
             ->willReturn($expectedResult);
@@ -66,7 +66,7 @@ class PlansTest extends ApiTestCase
         ];
 
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('post')
             ->with('/plan', $input)
             ->willReturn($expectedResult);
@@ -84,7 +84,7 @@ class PlansTest extends ApiTestCase
         $planId = 'PLN_x123';
 
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('put')
             ->with("/plan/$planId", $input)
             ->willReturn($expectedResult);
@@ -99,7 +99,7 @@ class PlansTest extends ApiTestCase
     {
         $api = $this->getApiMock();
 
-        self::assertInstanceOf(Plans::class, $api);
+        $this->assertInstanceOf(Plans::class, $api);
     }
 
     /**

--- a/test/Api/RefundTest.php
+++ b/test/Api/RefundTest.php
@@ -31,7 +31,7 @@ class RefundTest extends ApiTestCase
         $reference = 'RF_X1234';
 
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('get')
             ->with(self::PATH.'/'.$reference)
             ->willReturn($expectedResult);
@@ -47,7 +47,7 @@ class RefundTest extends ApiTestCase
         $expectedResult = ['data' => [['integration' => 900713]]];
 
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('get')
             ->with(self::PATH)
             ->willReturn($expectedResult);
@@ -67,7 +67,7 @@ class RefundTest extends ApiTestCase
         ];
 
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('post')
             ->with(self::PATH, $input)
             ->willReturn($expectedResult);
@@ -82,7 +82,7 @@ class RefundTest extends ApiTestCase
     {
         $api = $this->getApiMock();
 
-        self::assertInstanceOf(Refund::class, $api);
+        $this->assertInstanceOf(Refund::class, $api);
     }
 
     /**

--- a/test/Api/SettlementsTest.php
+++ b/test/Api/SettlementsTest.php
@@ -33,7 +33,7 @@ class SettlementsTest extends ApiTestCase
         ]);
 
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('get')
             ->with('/settlement')
             ->willReturn($finalResult);
@@ -48,7 +48,7 @@ class SettlementsTest extends ApiTestCase
     {
         $api = $this->getApiMock();
 
-        self::assertInstanceOf(Settlements::class, $api);
+        $this->assertInstanceOf(Settlements::class, $api);
     }
 
     /**

--- a/test/Api/SubAccountTest.php
+++ b/test/Api/SubAccountTest.php
@@ -30,7 +30,7 @@ class SubAccountTest extends ApiTestCase
         $account = 'ACC_x123';
 
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('get')
             ->with('/subaccount/'.$account)
             ->willReturn($expectedResult);
@@ -50,7 +50,7 @@ class SubAccountTest extends ApiTestCase
         ]);
 
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('get')
             ->with('/subaccount')
             ->willReturn($finalResult);
@@ -72,7 +72,7 @@ class SubAccountTest extends ApiTestCase
         ];
 
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('post')
             ->with('/subaccount', $input)
             ->willReturn($expectedResult);
@@ -90,7 +90,7 @@ class SubAccountTest extends ApiTestCase
         $accountId = 'ACC_x123';
 
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('put')
             ->with("/subaccount/$accountId", $input)
             ->willReturn($expectedResult);
@@ -105,7 +105,7 @@ class SubAccountTest extends ApiTestCase
     {
         $api = $this->getApiMock();
 
-        self::assertInstanceOf(SubAccount::class, $api);
+        $this->assertInstanceOf(SubAccount::class, $api);
     }
 
     /**

--- a/test/Api/SubscriptionsTest.php
+++ b/test/Api/SubscriptionsTest.php
@@ -32,7 +32,7 @@ class SubscriptionsTest extends ApiTestCase
         $subId = 'SUB_x123';
 
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('get')
             ->with(self::PATH.'/'.$subId)
             ->willReturn($expectedResult);
@@ -52,7 +52,7 @@ class SubscriptionsTest extends ApiTestCase
         ]);
 
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('get')
             ->with(self::PATH)
             ->willReturn($finalResult);
@@ -74,7 +74,7 @@ class SubscriptionsTest extends ApiTestCase
         ];
 
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('post')
             ->with(self::PATH, $input)
             ->willReturn($expectedResult);
@@ -91,7 +91,7 @@ class SubscriptionsTest extends ApiTestCase
         $expectedResult = ['message' => 'Subscription disabled successfully'];
 
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('post')
             ->with(self::PATH.'/disable', $input)
             ->willReturn($expectedResult);
@@ -108,7 +108,7 @@ class SubscriptionsTest extends ApiTestCase
         $expectedResult = ['message' => 'Subscription enabled successfully'];
 
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('post')
             ->with(self::PATH.'/enable', $input)
             ->willReturn($expectedResult);
@@ -123,7 +123,7 @@ class SubscriptionsTest extends ApiTestCase
     {
         $api = $this->getApiMock();
 
-        self::assertInstanceOf(Subscriptions::class, $api);
+        $this->assertInstanceOf(Subscriptions::class, $api);
     }
 
     /**

--- a/test/Api/TransactionsTest.php
+++ b/test/Api/TransactionsTest.php
@@ -30,7 +30,7 @@ class TransactionsTest extends ApiTestCase
         $expectedResult = ['data' => ['amount' => 50000]];
 
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('get')
             ->with('/transaction/verify/'.$reference)
             ->willReturn($expectedResult);
@@ -53,7 +53,7 @@ class TransactionsTest extends ApiTestCase
         $expectedResult = ['data' => ['amount' => 5000]];
 
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('post')
             ->with('/transaction/charge_authorization', $input)
             ->willReturn($expectedResult);
@@ -75,7 +75,7 @@ class TransactionsTest extends ApiTestCase
         $expectedResult = ['data' => ['authorization_url' => 'https://checkout.paystack.com/0peioxfhpn']];
 
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('post')
             ->with('/transaction/initialize', $input)
             ->willReturn($expectedResult);
@@ -95,7 +95,7 @@ class TransactionsTest extends ApiTestCase
         ]);
 
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('get')
             ->with('/transaction')
             ->willReturn($finalResult);
@@ -112,7 +112,7 @@ class TransactionsTest extends ApiTestCase
         $id = 123;
 
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('get')
             ->with('/transaction/'.$id)
             ->willReturn($expectedResult);
@@ -129,7 +129,7 @@ class TransactionsTest extends ApiTestCase
         $id = 'x123';
 
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('get')
             ->with('/transaction/timeline/'.$id)
             ->willReturn($expectedResult);
@@ -145,7 +145,7 @@ class TransactionsTest extends ApiTestCase
         $expectedResult = ['data' => ['total_transactions' => 900]];
 
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('get')
             ->with('/transaction/totals')
             ->willReturn($expectedResult);
@@ -160,7 +160,7 @@ class TransactionsTest extends ApiTestCase
     {
         $expectedResult = ['data' => ['path' => 'https://example.com/file.csv']];
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('get')
             ->with('/transaction/export')
             ->willReturn($expectedResult);
@@ -182,7 +182,7 @@ class TransactionsTest extends ApiTestCase
         $expectedResult = ['data' => ['reauthorization_url' => 'https://checkout.paystack.com/0peioxfhpn']];
 
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('post')
             ->with('/transaction/request_reauthorization', $input)
             ->willReturn($expectedResult);
@@ -204,7 +204,7 @@ class TransactionsTest extends ApiTestCase
         $expectedResult = ['data' => ['amount' => 400]];
 
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('post')
             ->with('/transaction/check_authorization', $input)
             ->willReturn($expectedResult);
@@ -219,7 +219,7 @@ class TransactionsTest extends ApiTestCase
     {
         $api = $this->getApiMock();
 
-        self::assertInstanceOf(Transactions::class, $api);
+        $this->assertInstanceOf(Transactions::class, $api);
     }
 
     /**

--- a/test/Api/TransferRecipientsTest.php
+++ b/test/Api/TransferRecipientsTest.php
@@ -32,7 +32,7 @@ class TransferRecipientsTest extends ApiTestCase
         $recipientId = 'RCP_x123';
 
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('delete')
             ->with(self::PATH.'/'.$recipientId)
             ->willReturn($expectedResult);
@@ -52,7 +52,7 @@ class TransferRecipientsTest extends ApiTestCase
         ]);
 
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('get')
             ->with(self::PATH)
             ->willReturn($finalResult);
@@ -72,7 +72,7 @@ class TransferRecipientsTest extends ApiTestCase
         ];
 
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('post')
             ->with(self::PATH, $input)
             ->willReturn($expectedResult);
@@ -90,7 +90,7 @@ class TransferRecipientsTest extends ApiTestCase
         $recipientId = 'RCP_x123';
 
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('put')
             ->with(self::PATH."/$recipientId", $input)
             ->willReturn($expectedResult);
@@ -105,7 +105,7 @@ class TransferRecipientsTest extends ApiTestCase
     {
         $api = $this->getApiMock();
 
-        self::assertInstanceOf(TransferRecipients::class, $api);
+        $this->assertInstanceOf(TransferRecipients::class, $api);
     }
 
     /**

--- a/test/Api/TransfersTest.php
+++ b/test/Api/TransfersTest.php
@@ -32,7 +32,7 @@ class TransfersTest extends ApiTestCase
         $transferId = 'TRF_2x5j67tnnw1t98k';
 
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('get')
             ->with(self::PATH.'/'.$transferId)
             ->willReturn($expectedResult);
@@ -52,7 +52,7 @@ class TransfersTest extends ApiTestCase
         ]);
 
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('get')
             ->with(self::PATH)
             ->willReturn($finalResult);
@@ -73,7 +73,7 @@ class TransfersTest extends ApiTestCase
         ];
 
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('post')
             ->with(self::PATH, $input)
             ->willReturn($expectedResult);
@@ -96,7 +96,7 @@ class TransfersTest extends ApiTestCase
         ];
 
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('post')
             ->with(self::PATH.'/bulk', $input)
             ->willReturn($expectedResult);
@@ -116,7 +116,7 @@ class TransfersTest extends ApiTestCase
         ];
 
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('post')
             ->with(self::PATH.'/finalize_transfer', $input)
             ->willReturn($expectedResult);
@@ -136,7 +136,7 @@ class TransfersTest extends ApiTestCase
         ];
 
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('post')
             ->with(self::PATH.'/resend_otp', $input)
             ->willReturn($expectedResult);
@@ -153,7 +153,7 @@ class TransfersTest extends ApiTestCase
         $input = [];
 
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('post')
             ->with(self::PATH.'/disable_otp', $input)
             ->willReturn($expectedResult);
@@ -170,7 +170,7 @@ class TransfersTest extends ApiTestCase
         $input = [];
 
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('post')
             ->with(self::PATH.'/enable_otp', $input)
             ->willReturn($expectedResult);
@@ -189,7 +189,7 @@ class TransfersTest extends ApiTestCase
         ];
 
         $api = $this->getApiMock();
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('post')
             ->with(self::PATH.'/disable_otp_finalize', $input)
             ->willReturn($expectedResult);
@@ -204,7 +204,7 @@ class TransfersTest extends ApiTestCase
     {
         $api = $this->getApiMock();
 
-        self::assertInstanceOf(Transfers::class, $api);
+        $this->assertInstanceOf(Transfers::class, $api);
     }
 
     /**

--- a/test/HttpClient/BuilderTest.php
+++ b/test/HttpClient/BuilderTest.php
@@ -17,7 +17,7 @@ final class BuilderTest extends TestCase
             ->setMethods(['addPlugin', 'removePlugin'])
             ->getMock();
 
-        $builder->expects(self::once())
+        $builder->expects($this->once())
             ->method('removePlugin')
             ->with(HeaderAppendPlugin::class);
 
@@ -34,10 +34,10 @@ final class BuilderTest extends TestCase
         $client = $this->getMockBuilder(Builder::class)
             ->setMethods(['addPlugin', 'removePlugin'])
             ->getMock();
-        $client->expects(self::once())
+        $client->expects($this->once())
             ->method('addPlugin')
-            ->with(self::isInstanceOf(HeaderAppendPlugin::class));
-        $client->expects(self::once())
+            ->with($this->isInstanceOf(HeaderAppendPlugin::class));
+        $client->expects($this->once())
             ->method('removePlugin')
             ->with(HeaderAppendPlugin::class);
 

--- a/test/HttpClient/Plugin/PaystackExceptionThrowerTest.php
+++ b/test/HttpClient/Plugin/PaystackExceptionThrowerTest.php
@@ -45,7 +45,7 @@ final class PaystackExceptionThrowerTest extends TestCase
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
 
-        $promise->expects(self::once())
+        $promise->expects($this->once())
             ->method('then')
             ->willReturnCallback(function ($callback) use ($response) {
                 return $callback($response);

--- a/test/Model/ModelTest.php
+++ b/test/Model/ModelTest.php
@@ -11,14 +11,14 @@ class ModelTest extends TestCase
     {
         $model = $this->getModel();
 
-        self::assertNotEquals(null, $model, 'Cannot create a Model instance');
+        $this->assertNotNull($model, 'Cannot create a Model instance');
     }
 
     public function testCanCreateModelInstanceWithAttributes()
     {
         $model = $this->getModel(['name' => 'bosun']);
 
-        self::assertNotEquals(null, $model, 'Cannot create model instance with attributes');
+        $this->assertNotNull($model, 'Cannot create model instance with attributes');
     }
 
     public function testCanRetrieveAttributes()
@@ -26,7 +26,7 @@ class ModelTest extends TestCase
         $attributes = ['name' => 'bosun'];
         $model = $this->getModel($attributes);
 
-        self::assertSame($model->getAttributes(), $attributes, 'Model did not return original attributes');
+        $this->assertSame($model->getAttributes(), $attributes, 'Model did not return original attributes');
     }
 
     public function testCanRetrieveAnAttribute()
@@ -34,7 +34,7 @@ class ModelTest extends TestCase
         $attributes = ['name' => 'bosun'];
         $model = $this->getModel($attributes);
 
-        self::assertSame($model->getAttribute('name'), $attributes['name'], 'Model cannot retrieve an attribute');
+        $this->assertSame($model->getAttribute('name'), $attributes['name'], 'Model cannot retrieve an attribute');
     }
 
     public function testCanSetAttributesUsingFillMethod()
@@ -43,7 +43,7 @@ class ModelTest extends TestCase
         $model = $this->getModel($attributes);
         $model->fill($attributes);
 
-        self::assertSame($model->getAttributes(), $attributes, 'Model Cannot set attributes using fill method');
+        $this->assertSame($model->getAttributes(), $attributes, 'Model Cannot set attributes using fill method');
     }
 
     public function testCanDynamicallyRetrievesAModelAttribute()
@@ -52,13 +52,13 @@ class ModelTest extends TestCase
         $model = $this->getModel($attributes);
         $model->fill($attributes);
 
-        self::assertSame($model->name, $attributes['name'], 'Model cannot retrieve attribute dynamically.');
+        $this->assertSame($model->name, $attributes['name'], 'Model cannot retrieve attribute dynamically.');
     }
 
     public function testModelWillReturnNullIfAttributeNotExists()
     {
         $model = $this->getModel([]);
-        self::assertNull($model->name, 'Model did not return null when attribute is not set');
+        $this->assertNull($model->name, 'Model did not return null when attribute is not set');
     }
 
     public function getModel($attributes = []): Model

--- a/test/PaystackTest.php
+++ b/test/PaystackTest.php
@@ -31,7 +31,7 @@ class PaystackTest extends TestCase
      */
     protected $paystack;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->paystack = new Paystack('public-key', 'secret-key');
     }

--- a/test/RequiredParameterTest.php
+++ b/test/RequiredParameterTest.php
@@ -26,7 +26,7 @@ class RequiredParameterTest extends TestCase
      */
     private $required;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->required = new Validator();
     }


### PR DESCRIPTION
# Changed log
- To be consistency, let assertion and mock methods call use `$this`.