### PR TITLE
Resolves issue #11

### DIFF
--- a/test/HttpClient/Message/ResponseMediatorTest.php
+++ b/test/HttpClient/Message/ResponseMediatorTest.php
@@ -24,7 +24,10 @@ use Xeviant\Paystack\HttpClient\Message\ResponseMediator;
 
 class ResponseMediatorTest extends TestCase
 {
-    public function testGetContent()
+    /**
+     * @test
+     */
+    public function shouldGetContent()
     {
         $body = ['foo' => 'bax'];
         $response = new Response(
@@ -36,7 +39,10 @@ class ResponseMediatorTest extends TestCase
         $this->assertEquals($body, ResponseMediator::getContent($response));
     }
 
-    public function testGetContentNotJSON()
+    /**
+     * @test
+     */
+    public function shouldGetContentNotJSON()
     {
         $body = 'foobar';
         $response = new Response(
@@ -48,7 +54,10 @@ class ResponseMediatorTest extends TestCase
         $this->assertEquals($body, ResponseMediator::getContent($response));
     }
 
-    public function testGetContentInvalidJSON()
+    /**
+     * @test
+     */
+    public function shouldGetContentInvalidJSON()
     {
         $body = 'foobar';
         $response = new Response(
@@ -60,7 +69,10 @@ class ResponseMediatorTest extends TestCase
         $this->assertEquals($body, ResponseMediator::getContent($response));
     }
 
-    public function testGetHeader()
+    /**
+     * @test
+     */
+    public function shouldGetHeader()
     {
         $header = 'application/json';
         $response = new Response(
@@ -71,7 +83,10 @@ class ResponseMediatorTest extends TestCase
         $this->assertEquals($header, ResponseMediator::getHeader($response, 'content-type'));
     }
 
-    public function testGetApiLimit()
+    /**
+     * @test
+     */
+    public function shouldGetApiLimit()
     {
         $header = 5000;
         $response = new Response(
@@ -82,7 +97,10 @@ class ResponseMediatorTest extends TestCase
         $this->assertEquals($header, ResponseMediator::getApiLimit($response));
     }
 
-    public function testExceptionIsThrownWhenApiLimitIsExceeded()
+    /**
+     * @test
+     */
+    public function shouldExceptionIsThrownWhenApiLimitIsExceeded()
     {
         $this->expectException(ApiLimitExceededException::class);
         $header = 0;

--- a/test/HttpClient/Plugin/PaystackExceptionThrowerTest.php
+++ b/test/HttpClient/Plugin/PaystackExceptionThrowerTest.php
@@ -29,6 +29,8 @@ use Xeviant\Paystack\HttpClient\Plugin\PaystackExceptionThrower;
 final class PaystackExceptionThrowerTest extends TestCase
 {
     /**
+     * @test
+     *
      * @param ResponseInterface       $response
      * @param ExceptionInterface|null $exception
      *
@@ -36,7 +38,7 @@ final class PaystackExceptionThrowerTest extends TestCase
      *
      * @throws \ReflectionException
      */
-    public function testHandleRequest(ResponseInterface $response, ExceptionInterface $exception = null)
+    public function shouldHandleRequest(ResponseInterface $response, ExceptionInterface $exception = null)
     {
         $request = $this->getMockForAbstractClass(RequestInterface::class);
 

--- a/test/Model/ModelTest.php
+++ b/test/Model/ModelTest.php
@@ -7,21 +7,30 @@ use Xeviant\Paystack\Tests\TestCase;
 
 class ModelTest extends TestCase
 {
-    public function testCanCreateModelInstance()
+    /**
+     * @test
+     */
+    public function canCreateModelInstance()
     {
         $model = $this->getModel();
 
         $this->assertNotNull($model, 'Cannot create a Model instance');
     }
 
-    public function testCanCreateModelInstanceWithAttributes()
+    /**
+     * @test
+     */
+    public function canCreateModelInstanceWithAttributes()
     {
         $model = $this->getModel(['name' => 'bosun']);
 
         $this->assertNotNull($model, 'Cannot create model instance with attributes');
     }
 
-    public function testCanRetrieveAttributes()
+    /**
+     * @test
+     */
+    public function canRetrieveAttributes()
     {
         $attributes = ['name' => 'bosun'];
         $model = $this->getModel($attributes);
@@ -29,7 +38,10 @@ class ModelTest extends TestCase
         $this->assertSame($model->getAttributes(), $attributes, 'Model did not return original attributes');
     }
 
-    public function testCanRetrieveAnAttribute()
+    /**
+     * @test
+     */
+    public function canRetrieveAnAttribute()
     {
         $attributes = ['name' => 'bosun'];
         $model = $this->getModel($attributes);
@@ -37,7 +49,10 @@ class ModelTest extends TestCase
         $this->assertSame($model->getAttribute('name'), $attributes['name'], 'Model cannot retrieve an attribute');
     }
 
-    public function testCanSetAttributesUsingFillMethod()
+    /**
+     * @test
+     */
+    public function canSetAttributesUsingFillMethod()
     {
         $attributes = ['name' => 'bosun'];
         $model = $this->getModel($attributes);
@@ -46,7 +61,10 @@ class ModelTest extends TestCase
         $this->assertSame($model->getAttributes(), $attributes, 'Model Cannot set attributes using fill method');
     }
 
-    public function testCanDynamicallyRetrievesAModelAttribute()
+    /**
+     * @test
+     */
+    public function canDynamicallyRetrievesAModelAttribute()
     {
         $attributes = ['name' => 'bosun'];
         $model = $this->getModel($attributes);
@@ -55,7 +73,10 @@ class ModelTest extends TestCase
         $this->assertSame($model->name, $attributes['name'], 'Model cannot retrieve attribute dynamically.');
     }
 
-    public function testModelWillReturnNullIfAttributeNotExists()
+    /**
+     * @test
+     */
+    public function modelWillReturnNullIfAttributeNotExists()
     {
         $model = $this->getModel([]);
         $this->assertNull($model->name, 'Model did not return null when attribute is not set');

--- a/test/PaystackTest.php
+++ b/test/PaystackTest.php
@@ -44,7 +44,7 @@ class PaystackTest extends TestCase
     /**
      * @test
      */
-    public function test_it_can_create_a_new_instance_using_make_method()
+    public function it_can_create_a_new_instance_using_make_method()
     {
         $paystack = Paystack::make('public-key', 'secret-key');
         $this->assertEquals('public-key', $paystack->getPublicKey());
@@ -52,14 +52,20 @@ class PaystackTest extends TestCase
         $this->assertEquals('1.0', $paystack->getApiVersion());
     }
 
-    public function test_it_can_create_a_new_instance_using_env_variables()
+    /**
+     * @test
+     */
+    public function it_can_create_a_new_instance_using_env_variables()
     {
         $paystack = new Paystack();
         $this->assertEquals(getenv('PAYSTACK_PUBLIC_KEY'), $paystack->getPublicKey());
         $this->assertEquals(getenv('PAYSTACK_SECRET_KEY'), $paystack->getSecretKey());
     }
 
-    public function test_it_can_set_and_get_public_and_secret_keys()
+    /**
+     * @test
+     */
+    public function it_can_set_and_get_public_and_secret_keys()
     {
         $this->paystack->setPublicKey('pk_test_1234');
         $this->paystack->setSecretKey('sk_test_1234');
@@ -68,7 +74,10 @@ class PaystackTest extends TestCase
         $this->assertEquals('pk_test_1234', $this->paystack->getPublicKey());
     }
 
-    public function test_it_throws_an_exception_when_the_public_or_secret_key_is_not_set()
+    /**
+     * @test
+     */
+    public function it_throws_an_exception_when_the_public_or_secret_key_is_not_set()
     {
         $this->expectException(RuntimeException::class);
         putenv('PAYSTACK_PUBLIC_KEY');
@@ -77,24 +86,36 @@ class PaystackTest extends TestCase
         new Paystack();
     }
 
-    public function test_it_can_set_and_get_api_version()
+    /**
+     * @test
+     */
+    public function it_can_set_and_get_api_version()
     {
         $this->paystack->setApiVersion('1.0');
 
         $this->assertEquals('1.0', $this->paystack->getApiVersion());
     }
 
-    public function test_it_can_get_the_current_package_version()
+    /**
+     * @test
+     */
+    public function it_can_get_the_current_package_version()
     {
         $this->assertNotEmpty($this->paystack->getPackageVersion());
     }
 
-    public function test_it_can_create_request()
+    /**
+     * @test
+     */
+    public function it_can_create_request()
     {
         $this->assertNotNull($this->paystack->customers());
     }
 
-    public function test_if_exception_is_thrown_when_the_request_is_invalid()
+    /**
+     * @test
+     */
+    public function if_exception_is_thrown_when_the_request_is_invalid()
     {
         $this->expectException(InvalidArgumentException::class);
         $this->paystack->thisApiDoesNotExist();

--- a/test/RequiredParameterTest.php
+++ b/test/RequiredParameterTest.php
@@ -36,7 +36,10 @@ class RequiredParameterTest extends TestCase
         $this->required = null;
     }
 
-    public function testShouldSetAndGetRequiredParameters(): void
+    /**
+     * @test
+     */
+    public function shouldSetAndGetRequiredParameters(): void
     {
         $requiredParameters = collect(['name', 'email']);
         $this->required->setRequiredParameters($requiredParameters);
@@ -48,7 +51,7 @@ class RequiredParameterTest extends TestCase
      * @test
      * @expectedException \Xeviant\Paystack\Exception\MissingArgumentException
      */
-    public function testShouldThrowExceptionWhenRequiredParameterIsMissing()
+    public function shouldThrowExceptionWhenRequiredParameterIsMissing()
     {
         $values = ['name' => 'Bosun'];
         $this->required->setRequiredParameters(collect(['email']));
@@ -56,9 +59,9 @@ class RequiredParameterTest extends TestCase
     }
 
     /**
-     * @return void
+     * @test
      */
-    public function testShouldNotThrowExceptionWhenRequiredParameterIsPresent(): void
+    public function shouldNotThrowExceptionWhenRequiredParameterIsPresent(): void
     {
         $values = ['name' => 'Bosun'];
         $this->required->setRequiredParameters(collect(['name']));


### PR DESCRIPTION
# Changed log
- Resolves issue #11.
- It seems that using the `@test` comment annotation is greater than using prefix-based `test` method declarations.
And let all test methods be `@test` comment annotation approach.