### PR TITLE
Consistency for native type hint and exceptions

### DIFF
--- a/test/Api/AbstractApiTest.php
+++ b/test/Api/AbstractApiTest.php
@@ -19,6 +19,7 @@ namespace Xeviant\Paystack\Tests\Api;
 use GuzzleHttp\Psr7\Response;
 use function GuzzleHttp\Psr7\stream_for;
 use Http\Client\Common\HttpMethodsClientInterface;
+use PHPUnit\Framework\MockObject\MockObject;
 use Xeviant\Paystack\Api\AbstractApi;
 use Xeviant\Paystack\Client;
 
@@ -27,7 +28,7 @@ class AbstractApiTest extends ApiTestCase
     /**
      * @test
      */
-    public function shouldPassGETRequestToClient()
+    public function shouldPassGETRequestToClient(): void
     {
         $expectedArray = ['value'];
 
@@ -55,7 +56,7 @@ class AbstractApiTest extends ApiTestCase
     /**
      * @test
      */
-    public function shouldPassPOSTRequestToClient()
+    public function shouldPassPOSTRequestToClient(): void
     {
         $expectedResult = ['value'];
 
@@ -85,7 +86,7 @@ class AbstractApiTest extends ApiTestCase
      *
      * @throws \ReflectionException
      */
-    public function shouldPassPATCHRequestToClient()
+    public function shouldPassPATCHRequestToClient(): void
     {
         $expectedValue = ['value'];
 
@@ -114,7 +115,7 @@ class AbstractApiTest extends ApiTestCase
      *
      * @throws \ReflectionException
      */
-    public function shouldPassPUTRequestToClient()
+    public function shouldPassPUTRequestToClient(): void
     {
         $expectedValue = ['value'];
 
@@ -144,7 +145,7 @@ class AbstractApiTest extends ApiTestCase
      *
      * @throws \ReflectionException
      */
-    public function shouldPassDELETERequest()
+    public function shouldPassDELETERequest(): void
     {
         $expectedValue = ['value'];
 
@@ -168,7 +169,7 @@ class AbstractApiTest extends ApiTestCase
         $this->assertEquals($expectedValue, $actual);
     }
 
-    public function getHttpMethodsMock(array $methods = [])
+    public function getHttpMethodsMock(array $methods = []): MockObject
     {
         $methods = array_merge(['sendRequest'], $methods);
 
@@ -197,7 +198,7 @@ class AbstractApiTest extends ApiTestCase
         );
     }
 
-    protected function getAbstractApiObject($client)
+    protected function getAbstractApiObject($client): MockObject
     {
         return $this->getMockBuilder($this->getApiClass())
             ->setMethods(null)

--- a/test/Api/BalanceTest.php
+++ b/test/Api/BalanceTest.php
@@ -41,7 +41,7 @@ class BalanceTest extends ApiTestCase
     /**
      * @test
      */
-    public function shouldGetBalanceApiObject()
+    public function shouldGetBalanceApiObject(): void
     {
         $api = $this->getApiMock();
 

--- a/test/Api/BankTest.php
+++ b/test/Api/BankTest.php
@@ -41,7 +41,7 @@ class BankTest extends ApiTestCase
     /**
      * @test
      */
-    public function shouldGetBankApiObject()
+    public function shouldGetBankApiObject(): void
     {
         $api = $this->getApiMock();
 

--- a/test/Api/BulkChargesTest.php
+++ b/test/Api/BulkChargesTest.php
@@ -126,7 +126,7 @@ class BulkChargesTest extends ApiTestCase
     /**
      * @test
      */
-    public function shouldGetBulkChargesApiObject()
+    public function shouldGetBulkChargesApiObject(): void
     {
         $api = $this->getApiMock();
 

--- a/test/Api/BvnTest.php
+++ b/test/Api/BvnTest.php
@@ -100,7 +100,7 @@ class BvnTest extends ApiTestCase
     /**
      * @test
      */
-    public function shouldGetBvnApiObject()
+    public function shouldGetBvnApiObject(): void
     {
         $api = $this->getApiMock();
 

--- a/test/Api/ChargeTest.php
+++ b/test/Api/ChargeTest.php
@@ -185,7 +185,7 @@ class ChargeTest extends ApiTestCase
     /**
      * @test
      */
-    public function shouldGetTransactionsApiObject()
+    public function shouldGetTransactionsApiObject(): void
     {
         $api = $this->getApiMock();
 

--- a/test/Api/CustomerTest.php
+++ b/test/Api/CustomerTest.php
@@ -90,7 +90,7 @@ class CustomerTest extends ApiTestCase
     /**
      * @test
      */
-    public function shouldWhiteListCustomer()
+    public function shouldWhiteListCustomer(): void
     {
         $customer = 'CUS_xbxb';
         $input = ['customer' => $customer, 'risk_action' => 'allow'];
@@ -108,7 +108,7 @@ class CustomerTest extends ApiTestCase
     /**
      * @test
      */
-    public function shouldBlackListCustomer()
+    public function shouldBlackListCustomer(): void
     {
         $customer = 'CUS_xbxb';
         $input = ['customer' => $customer, 'risk_action' => 'deny'];
@@ -126,7 +126,7 @@ class CustomerTest extends ApiTestCase
     /**
      * @test
      */
-    public function shouldDeactivateAuthorization()
+    public function shouldDeactivateAuthorization(): void
     {
         $input = ['authorization_code' => 'AUTH_au6hc0de'];
         $expectedResult = ['status' => true, 'message' => 'Authorization has been disabled'];

--- a/test/Api/IntegrationTest.php
+++ b/test/Api/IntegrationTest.php
@@ -58,7 +58,7 @@ class IntegrationTest extends ApiTestCase
     /**
      * @test
      */
-    public function shouldGetTransactionsApiObject()
+    public function shouldGetTransactionsApiObject(): void
     {
         $api = $this->getApiMock();
 

--- a/test/Api/InvoicesTest.php
+++ b/test/Api/InvoicesTest.php
@@ -210,7 +210,7 @@ class InvoicesTest extends ApiTestCase
     /**
      * @test
      */
-    public function shouldGetTransactionsApiObject()
+    public function shouldGetTransactionsApiObject(): void
     {
         $api = $this->getApiMock();
 

--- a/test/Api/PagesTest.php
+++ b/test/Api/PagesTest.php
@@ -119,7 +119,7 @@ class PagesTest extends ApiTestCase
     /**
      * @test
      */
-    public function shouldGetTransactionsApiObject()
+    public function shouldGetTransactionsApiObject(): void
     {
         $api = $this->getApiMock();
 

--- a/test/Api/PlansTest.php
+++ b/test/Api/PlansTest.php
@@ -95,7 +95,7 @@ class PlansTest extends ApiTestCase
     /**
      * @test
      */
-    public function shouldGetTransactionsApiObject()
+    public function shouldGetTransactionsApiObject(): void
     {
         $api = $this->getApiMock();
 

--- a/test/Api/RefundTest.php
+++ b/test/Api/RefundTest.php
@@ -78,7 +78,7 @@ class RefundTest extends ApiTestCase
     /**
      * @test
      */
-    public function shouldGetTransactionsApiObject()
+    public function shouldGetTransactionsApiObject(): void
     {
         $api = $this->getApiMock();
 

--- a/test/Api/SettlementsTest.php
+++ b/test/Api/SettlementsTest.php
@@ -44,7 +44,7 @@ class SettlementsTest extends ApiTestCase
     /**
      * @test
      */
-    public function shouldGetTransactionsApiObject()
+    public function shouldGetTransactionsApiObject(): void
     {
         $api = $this->getApiMock();
 

--- a/test/Api/SubAccountTest.php
+++ b/test/Api/SubAccountTest.php
@@ -101,7 +101,7 @@ class SubAccountTest extends ApiTestCase
     /**
      * @test
      */
-    public function shouldGetTransactionsApiObject()
+    public function shouldGetTransactionsApiObject(): void
     {
         $api = $this->getApiMock();
 

--- a/test/Api/SubscriptionsTest.php
+++ b/test/Api/SubscriptionsTest.php
@@ -119,7 +119,7 @@ class SubscriptionsTest extends ApiTestCase
     /**
      * @test
      */
-    public function shouldGetTransactionsApiObject()
+    public function shouldGetTransactionsApiObject(): void
     {
         $api = $this->getApiMock();
 

--- a/test/Api/TransactionsTest.php
+++ b/test/Api/TransactionsTest.php
@@ -24,7 +24,7 @@ class TransactionsTest extends ApiTestCase
     /**
      * @test
      */
-    public function shouldVerifyTransactions()
+    public function shouldVerifyTransactions(): void
     {
         $reference = 'DG4uishudoq90LD';
         $expectedResult = ['data' => ['amount' => 50000]];
@@ -41,7 +41,7 @@ class TransactionsTest extends ApiTestCase
     /**
      * @test
      */
-    public function shouldChargeReturningCustomer()
+    public function shouldChargeReturningCustomer(): void
     {
         $input = [
             'amount'             => 20000,
@@ -64,7 +64,7 @@ class TransactionsTest extends ApiTestCase
     /**
      * @test
      */
-    public function shouldInitializeTransaction()
+    public function shouldInitializeTransaction(): void
     {
         $input = [
             'reference' => '7PVGX8MEk85tgeEpVDtD',
@@ -171,7 +171,7 @@ class TransactionsTest extends ApiTestCase
     /**
      * @test
      */
-    public function shouldRequestReauthorization()
+    public function shouldRequestReauthorization(): void
     {
         $input = [
             'authorization_code' => '7PVGX8MEk85tgeEpVDtD',
@@ -193,7 +193,7 @@ class TransactionsTest extends ApiTestCase
     /**
      * @test
      */
-    public function shouldCheckAuthorization()
+    public function shouldCheckAuthorization(): void
     {
         $input = [
             'authorization_code' => '7PVGX8MEk85tgeEpVDtD',
@@ -215,7 +215,7 @@ class TransactionsTest extends ApiTestCase
     /**
      * @test
      */
-    public function shouldGetTransactionsApiObject()
+    public function shouldGetTransactionsApiObject(): void
     {
         $api = $this->getApiMock();
 

--- a/test/Api/TransferRecipientsTest.php
+++ b/test/Api/TransferRecipientsTest.php
@@ -101,7 +101,7 @@ class TransferRecipientsTest extends ApiTestCase
     /**
      * @test
      */
-    public function shouldGetTransactionsApiObject()
+    public function shouldGetTransactionsApiObject(): void
     {
         $api = $this->getApiMock();
 

--- a/test/Api/TransfersTest.php
+++ b/test/Api/TransfersTest.php
@@ -200,7 +200,7 @@ class TransfersTest extends ApiTestCase
     /**
      * @test
      */
-    public function shouldGetTransactionsApiObject()
+    public function shouldGetTransactionsApiObject(): void
     {
         $api = $this->getApiMock();
 

--- a/test/ClientTest.php
+++ b/test/ClientTest.php
@@ -29,7 +29,7 @@ final class ClientTest extends TestCase
     /**
      * @test
      */
-    public function shouldNotHaveToPassHttpClientToConstructor()
+    public function shouldNotHaveToPassHttpClientToConstructor(): void
     {
         $client = new Client();
 
@@ -39,7 +39,7 @@ final class ClientTest extends TestCase
     /**
      * @test
      */
-    public function shouldPassHttpClientInterfaceToConstructor()
+    public function shouldPassHttpClientInterfaceToConstructor(): void
     {
         $httpClientMock = $this->getMockBuilder(HttpClient::class)->getMock();
 
@@ -56,7 +56,7 @@ final class ClientTest extends TestCase
      * @test
      * @dataProvider getApiServiceProvider
      */
-    public function shouldGetApiInstance($apiName, $class)
+    public function shouldGetApiInstance($apiName, $class): void
     {
         $client = $this->createApplication()->make(Client::class);
 
@@ -71,7 +71,7 @@ final class ClientTest extends TestCase
      *
      * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
-    public function shouldMagicallyGetApiInstance($apiName, $class)
+    public function shouldMagicallyGetApiInstance($apiName, $class): void
     {
         $client = new Client();
 
@@ -81,7 +81,7 @@ final class ClientTest extends TestCase
     /**
      * @test
      */
-    public function shouldNotBeAbleToGetApiInstanceThatDoesntExits()
+    public function shouldNotBeAbleToGetApiInstanceThatDoesntExits(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $client = new Client();
@@ -93,7 +93,7 @@ final class ClientTest extends TestCase
      *
      * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
-    public function shouldNotBeAbleToGetMagicApiInstanceThatDoesntExits()
+    public function shouldNotBeAbleToGetMagicApiInstanceThatDoesntExits(): void
     {
         $this->expectException(BadMethodCallException::class);
         $client = new Client();

--- a/test/HttpClient/BuilderTest.php
+++ b/test/HttpClient/BuilderTest.php
@@ -11,7 +11,7 @@ final class BuilderTest extends TestCase
     /**
      * @test
      */
-    public function shouldClearHeaders()
+    public function shouldClearHeaders(): void
     {
         $builder = $this->getMockBuilder(Builder::class)
             ->setMethods(['addPlugin', 'removePlugin'])
@@ -27,7 +27,7 @@ final class BuilderTest extends TestCase
     /**
      * @test
      */
-    public function shouldAddHeaders()
+    public function shouldAddHeaders(): void
     {
         $headers = ['Header1', 'Header2'];
 
@@ -47,7 +47,7 @@ final class BuilderTest extends TestCase
     /**
      * @test
      */
-    public function appendingHeaderShouldAddAndRemovePlugin()
+    public function appendingHeaderShouldAddAndRemovePlugin(): void
     {
         $expectedHeaders = [
             'Accept' => 'application/json',

--- a/test/HttpClient/Message/ResponseMediatorTest.php
+++ b/test/HttpClient/Message/ResponseMediatorTest.php
@@ -27,7 +27,7 @@ class ResponseMediatorTest extends TestCase
     /**
      * @test
      */
-    public function shouldGetContent()
+    public function shouldGetContent(): void
     {
         $body = ['foo' => 'bax'];
         $response = new Response(
@@ -42,7 +42,7 @@ class ResponseMediatorTest extends TestCase
     /**
      * @test
      */
-    public function shouldGetContentNotJSON()
+    public function shouldGetContentNotJSON(): void
     {
         $body = 'foobar';
         $response = new Response(
@@ -57,7 +57,7 @@ class ResponseMediatorTest extends TestCase
     /**
      * @test
      */
-    public function shouldGetContentInvalidJSON()
+    public function shouldGetContentInvalidJSON(): void
     {
         $body = 'foobar';
         $response = new Response(
@@ -72,7 +72,7 @@ class ResponseMediatorTest extends TestCase
     /**
      * @test
      */
-    public function shouldGetHeader()
+    public function shouldGetHeader(): void
     {
         $header = 'application/json';
         $response = new Response(
@@ -86,7 +86,7 @@ class ResponseMediatorTest extends TestCase
     /**
      * @test
      */
-    public function shouldGetApiLimit()
+    public function shouldGetApiLimit(): void
     {
         $header = 5000;
         $response = new Response(
@@ -100,7 +100,7 @@ class ResponseMediatorTest extends TestCase
     /**
      * @test
      */
-    public function shouldExceptionIsThrownWhenApiLimitIsExceeded()
+    public function shouldExceptionIsThrownWhenApiLimitIsExceeded(): void
     {
         $this->expectException(ApiLimitExceededException::class);
         $header = 0;

--- a/test/HttpClient/Plugin/PaystackExceptionThrowerTest.php
+++ b/test/HttpClient/Plugin/PaystackExceptionThrowerTest.php
@@ -38,7 +38,7 @@ final class PaystackExceptionThrowerTest extends TestCase
      *
      * @throws \ReflectionException
      */
-    public function shouldHandleRequest(ResponseInterface $response, ExceptionInterface $exception = null)
+    public function shouldHandleRequest(ResponseInterface $response, ExceptionInterface $exception = null): void
     {
         $request = $this->getMockForAbstractClass(RequestInterface::class);
 

--- a/test/Model/ModelTest.php
+++ b/test/Model/ModelTest.php
@@ -10,7 +10,7 @@ class ModelTest extends TestCase
     /**
      * @test
      */
-    public function canCreateModelInstance()
+    public function canCreateModelInstance(): void
     {
         $model = $this->getModel();
 
@@ -20,7 +20,7 @@ class ModelTest extends TestCase
     /**
      * @test
      */
-    public function canCreateModelInstanceWithAttributes()
+    public function canCreateModelInstanceWithAttributes(): void
     {
         $model = $this->getModel(['name' => 'bosun']);
 
@@ -30,7 +30,7 @@ class ModelTest extends TestCase
     /**
      * @test
      */
-    public function canRetrieveAttributes()
+    public function canRetrieveAttributes(): void
     {
         $attributes = ['name' => 'bosun'];
         $model = $this->getModel($attributes);
@@ -41,7 +41,7 @@ class ModelTest extends TestCase
     /**
      * @test
      */
-    public function canRetrieveAnAttribute()
+    public function canRetrieveAnAttribute(): void
     {
         $attributes = ['name' => 'bosun'];
         $model = $this->getModel($attributes);
@@ -52,7 +52,7 @@ class ModelTest extends TestCase
     /**
      * @test
      */
-    public function canSetAttributesUsingFillMethod()
+    public function canSetAttributesUsingFillMethod(): void
     {
         $attributes = ['name' => 'bosun'];
         $model = $this->getModel($attributes);
@@ -64,7 +64,7 @@ class ModelTest extends TestCase
     /**
      * @test
      */
-    public function canDynamicallyRetrievesAModelAttribute()
+    public function canDynamicallyRetrievesAModelAttribute(): void
     {
         $attributes = ['name' => 'bosun'];
         $model = $this->getModel($attributes);
@@ -76,7 +76,7 @@ class ModelTest extends TestCase
     /**
      * @test
      */
-    public function modelWillReturnNullIfAttributeNotExists()
+    public function modelWillReturnNullIfAttributeNotExists(): void
     {
         $model = $this->getModel([]);
         $this->assertNull($model->name, 'Model did not return null when attribute is not set');

--- a/test/PaystackTest.php
+++ b/test/PaystackTest.php
@@ -31,12 +31,12 @@ class PaystackTest extends TestCase
      */
     protected $paystack;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->paystack = new Paystack('public-key', 'secret-key');
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->paystack = null;
     }
@@ -44,7 +44,7 @@ class PaystackTest extends TestCase
     /**
      * @test
      */
-    public function it_can_create_a_new_instance_using_make_method()
+    public function it_can_create_a_new_instance_using_make_method(): void
     {
         $paystack = Paystack::make('public-key', 'secret-key');
         $this->assertEquals('public-key', $paystack->getPublicKey());
@@ -55,7 +55,7 @@ class PaystackTest extends TestCase
     /**
      * @test
      */
-    public function it_can_create_a_new_instance_using_env_variables()
+    public function it_can_create_a_new_instance_using_env_variables(): void
     {
         $paystack = new Paystack();
         $this->assertEquals(getenv('PAYSTACK_PUBLIC_KEY'), $paystack->getPublicKey());
@@ -65,7 +65,7 @@ class PaystackTest extends TestCase
     /**
      * @test
      */
-    public function it_can_set_and_get_public_and_secret_keys()
+    public function it_can_set_and_get_public_and_secret_keys(): void
     {
         $this->paystack->setPublicKey('pk_test_1234');
         $this->paystack->setSecretKey('sk_test_1234');
@@ -77,7 +77,7 @@ class PaystackTest extends TestCase
     /**
      * @test
      */
-    public function it_throws_an_exception_when_the_public_or_secret_key_is_not_set()
+    public function it_throws_an_exception_when_the_public_or_secret_key_is_not_set(): void
     {
         $this->expectException(RuntimeException::class);
         putenv('PAYSTACK_PUBLIC_KEY');
@@ -89,7 +89,7 @@ class PaystackTest extends TestCase
     /**
      * @test
      */
-    public function it_can_set_and_get_api_version()
+    public function it_can_set_and_get_api_version(): void
     {
         $this->paystack->setApiVersion('1.0');
 
@@ -99,7 +99,7 @@ class PaystackTest extends TestCase
     /**
      * @test
      */
-    public function it_can_get_the_current_package_version()
+    public function it_can_get_the_current_package_version(): void
     {
         $this->assertNotEmpty($this->paystack->getPackageVersion());
     }
@@ -107,7 +107,7 @@ class PaystackTest extends TestCase
     /**
      * @test
      */
-    public function it_can_create_request()
+    public function it_can_create_request(): void
     {
         $this->assertNotNull($this->paystack->customers());
     }
@@ -115,7 +115,7 @@ class PaystackTest extends TestCase
     /**
      * @test
      */
-    public function if_exception_is_thrown_when_the_request_is_invalid()
+    public function if_exception_is_thrown_when_the_request_is_invalid(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->paystack->thisApiDoesNotExist();

--- a/test/RequiredParameterTest.php
+++ b/test/RequiredParameterTest.php
@@ -17,6 +17,7 @@
 namespace Xeviant\Paystack\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Xeviant\Paystack\Exception\MissingArgumentException;
 use Xeviant\Paystack\Validator;
 
 class RequiredParameterTest extends TestCase
@@ -26,12 +27,12 @@ class RequiredParameterTest extends TestCase
      */
     private $required;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->required = new Validator();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->required = null;
     }
@@ -49,10 +50,11 @@ class RequiredParameterTest extends TestCase
 
     /**
      * @test
-     * @expectedException \Xeviant\Paystack\Exception\MissingArgumentException
      */
-    public function shouldThrowExceptionWhenRequiredParameterIsMissing()
+    public function shouldThrowExceptionWhenRequiredParameterIsMissing(): void
     {
+        $this->expectException(MissingArgumentException::class);
+
         $values = ['name' => 'Bosun'];
         $this->required->setRequiredParameters(collect(['email']));
         $this->required->checkParameters($values);

--- a/test/TestCase.php
+++ b/test/TestCase.php
@@ -7,7 +7,7 @@ use Xeviant\Paystack\App\PaystackApplication;
 
 class TestCase extends PHPUnitTestCase
 {
-    public function createApplication()
+    public function createApplication(): PaystackApplication
     {
         return new PaystackApplication();
     }


### PR DESCRIPTION
# Changed log
- To be consistency, let all test methods have native type `void` hint.
- To be consistency, let the `@epxectedException` be the `$this->epxectException` method call.